### PR TITLE
Add multiple sorting

### DIFF
--- a/features/search.feature
+++ b/features/search.feature
@@ -199,7 +199,11 @@ Feature: Generate valid search queries with fake request id "11111"
         "node_id"
     ],
     "from" : 0, 
-    "size" : 20
+    "size" : 20,
+    "sort": [
+        "_score",
+        "_doc"
+    ]
     }
     """
 
@@ -402,7 +406,11 @@ Feature: Generate valid search queries with fake request id "11111"
         "node_id"
     ],
     "from" : 0, 
-    "size" : 20
+    "size" : 20,
+    "sort": [
+        "_score",
+        "_doc"
+    ]
     }
     """
 
@@ -615,7 +623,11 @@ Feature: Generate valid search queries with fake request id "11111"
         "node_id"
     ],
     "from" : 0, 
-    "size" : 20
+    "size" : 20,
+    "sort": [
+        "_score",
+        "_doc"
+    ]
     }
     """
 
@@ -795,7 +807,11 @@ Feature: Generate valid search queries with fake request id "11111"
         "node_id"
     ],
     "from" : 0, 
-    "size" : 20
+    "size" : 20,
+    "sort": [
+        "_score",
+        "_doc"
+    ]
     }
     """
 
@@ -988,7 +1004,11 @@ Feature: Generate valid search queries with fake request id "11111"
         "node_id"
     ],
     "from" : 0, 
-    "size" : 20
+    "size" : 20,
+    "sort": [
+        "_score",
+        "_doc"
+    ]
     }
     """
 
@@ -1312,7 +1332,11 @@ Feature: Generate valid search queries with fake request id "11111"
         "node_id"
     ],
     "from" : 0, 
-    "size" : 20
+    "size" : 20,
+    "sort": [
+        "_score",
+        "_doc"
+    ]
     }
     """
 
@@ -1526,7 +1550,11 @@ Feature: Generate valid search queries with fake request id "11111"
         "node_id"
     ],
     "from" : 0, 
-    "size" : 20
+    "size" : 20,
+    "sort": [
+        "_score",
+        "_doc"
+    ]
     }
     """
 

--- a/src/queryBuilder.php
+++ b/src/queryBuilder.php
@@ -436,7 +436,7 @@ class queryBuilder implements queryBuilderInterface
 		// construct function score
         $function_score = array("function_score" => array_merge(array("functions" => $functions["functions"], "query" => $main_query["query"]), $agg_modes));
 
-        return array("query" => $function_score, "_source" => $conf["source_fields"], "from"=>$from, "size"=>$size, "explain"=>$explain);
+        return array("query" => $function_score, "_source" => $conf["source_fields"], "from"=>$from, "size"=>$size, "explain"=>$explain,"sort"=>array("_score", "_doc"));
     }
 
     /**


### PR DESCRIPTION
Pull request pour ajouter le multi-sorting lors de la construction des requêtes.

- modification du code php pour ajouter le sort par score puis par id (matérialiser par le champs _doc car les ids des documents sont les ids des users)
- modification des tests unitaires en conséquence

Après quelques tests de temps de réponse, le changement n'a visiblement pas de conséquence.